### PR TITLE
fixed param parsing when there is no space at the end of a received string

### DIFF
--- a/src/xboard_interface.cpp
+++ b/src/xboard_interface.cpp
@@ -123,13 +123,18 @@ void XBoardInterface::CommandReceived::parse(std::string rcvd)
 {
     std::deque<std::string> params;
     std::size_t i = 0;
-    while (i != std::string::npos)
+    std::string rawcmd = rcvd; // make a copy
+
+    while ((i = rawcmd.find(' ')) != std::string::npos)
     {
-        std::size_t found = rcvd.find_first_of(" ", i);
-        params.push_back(rcvd.substr(i, found));
-        while(rcvd[found] == ' ') found++;
-        i = found;
+        params.push_back(rawcmd.substr(0, i));
+
+        // delete up to the delimeter AND the delimeter
+        rawcmd.erase(0, i + 1); 
     }
+    
+    if (!rawcmd.empty()) params.push_back(rawcmd);
+
     while (!params.empty())
     {
         std::string command = params[0];


### PR DESCRIPTION
I pulled this down and compiled it on Windows (VS2019). When I ran it through WinBoard I was getting crashes. I guess when it was originally developed there was an assumption that there would be a trailing space at the end of each command, which was not the case when I tried it. I fixed the split functionality.